### PR TITLE
Update convert.sh

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -3,7 +3,7 @@ echo `date`: Conversion starting ...
 
 XPROC="java -jar /usr/share/xmlcalabash-1.4.1-100/xmlcalabash-1.4.1-100.jar"
 
-git --work-tree=/usr/src/vmcp-word/ pull
+sudo -u tomcat git --work-tree=/usr/src/vmcp-word/ pull
 
 echo `date`: Copying figure image files ...
 sudo mkdir -p /etc/xproc-z/vmcp/figure

--- a/convert.sh
+++ b/convert.sh
@@ -1,9 +1,10 @@
 echo `date`: Conversion starting ...
 
-
 XPROC="java -jar /usr/share/xmlcalabash-1.4.1-100/xmlcalabash-1.4.1-100.jar"
 
-sudo -u tomcat git --work-tree=/usr/src/vmcp-word/ pull
+echo `date`: Retrieving Word files from github ...
+cd /usr/src/vmcp-word
+git pull
 
 echo `date`: Copying figure image files ...
 sudo mkdir -p /etc/xproc-z/vmcp/figure
@@ -26,4 +27,3 @@ echo `date`: Restarting Tomcat webserver ...
 sudo systemctl restart tomcat9
 sudo systemctl status tomcat9 --no-pager
 echo `date`: Conversion finished.
-


### PR DESCRIPTION
- I removed the initial conversion from Word 1997-2003 to Open Document Text, as agreed last week.
- Placed the TEI files under version control in GitHub; added commands to `convert.sh` to commit and push changes after the conversion from ODT to TEI has taken place.
- Removed command to purge the TEI folder, as that would delete Git-related files and README as well; we could add a command to find files that are more than 1 day old and delete them after the conversion, but files to be deleted should be a rare event, so I think it is better to not include it in the pipeline.