### PR TITLE
modify ./convert.sh

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -1,29 +1,24 @@
 echo `date`: Conversion starting ...
 
-
 XPROC="java -jar /usr/share/xmlcalabash-1.4.1-100/xmlcalabash-1.4.1-100.jar"
 
-git --work-tree=/usr/src/vmcp-word/ pull
+echo `date`: Retrieving ODT files from GitHub...
+cd /home/RBGV_Admin/vmcp-odt/ && git pull
 
-echo `date`: Copying figure image files ...
-sudo mkdir -p /etc/xproc-z/vmcp/figure
-sudo cp "/usr/src/vmcp-word/images in letters/"*.jpg /etc/xproc-z/vmcp/figure/
-
-echo `date`: Listing Word documents ...
-# generate conversion bash script
-sudo $XPROC /usr/src/VMCP-upconversion/xproc/convert.xpl input-root-folder=/usr/src/vmcp-word output-root-folder=/usr/src/VMCP-upconversion/odt output-shell-script=$HOME/convert-all.sh
-sudo chmod a+x ~/convert-all.sh
-sudo ~/convert-all.sh
-#rm convert-all.sh
-echo `date`: Purging existing TEI documents
-# TODO purge only documents that have been deleted in the original Word file (see the convert-all.sh script)
-sudo rm -r -f /usr/src/xtf/data/tei
 echo `date`: Converting OpenDocument files to TEI format ...
-sudo time $XPROC /usr/src/VMCP-upconversion/xproc/upconvert.xpl input-directory=/usr/src/VMCP-upconversion/odt output-directory=/usr/src/xtf/data/tei
+time $XPROC /usr/src/VMCP-upconversion/xproc/upconvert.xpl input-directory=/home/RBGV_Admin/vmcp-odt output-directory=/usr/src/xtf/data/tei
+
+echo `date`: Pushing changes in TEI to GitHub...
+cd /usr/src/xtf/data/tei
+git add .
+git commit -m "VMCP conversion pipeline run `date`"
+git push origin main
+
 echo `date`: Rebuilding XTF index ...
 sudo -u tomcat /usr/src/xtf/bin/textIndexer -clean -index default
+
 echo `date`: Restarting Tomcat webserver ...
 sudo systemctl restart tomcat9
 sudo systemctl status tomcat9 --no-pager
-echo `date`: Conversion finished.
 
+echo `date`: Conversion finished.


### PR DESCRIPTION
- I removed the initial conversion from Word 1997-2003 to Open Document Text, as agreed last week.
- Placed the TEI files under version control in GitHub; added commands to convert.sh to commit and push changes after the conversion from ODT to TEI has taken place.
- Removed command to purge the TEI folder, as that would delete Git-related files and README as well; we could add a command to find files that are more than 1 day old and delete them after the conversion, but files to be deleted should be a rare event, so I think it is better to not include it in the pipeline.